### PR TITLE
Fix error with module

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -77,10 +77,13 @@ function actionWrapper (action) {
  * Note: commits already performed won't be undone.
  */
 export function makeCancellable (actions) {
-  for (let action in actions) {
-    actions[action] = actionWrapper(actions[action])
-  }
-  return actions
+  return Object.keys(actions).reduce(
+    (acc, key) => {
+      acc[key] = actionWrapper(actions[key])
+      return acc
+    },
+    {}
+  )
 }
 
 /* Cancel an action that was made cancellable by the wrapper above.


### PR DESCRIPTION
If your actions are imported from a module (which is common):
```
import * as action from './actions';
```
`makeCancellable()` won't work because module exports only have getters and no setters (`actions[action] =` is the problem).

Also:
- Modifying a parameter (here `actions`) is never a good idea. It's more error proof to create a new `Object` with `reduce`.
- Don't use `for...in` to loop on object properties. Instead `Object.keys()` will make sure we only take properties owned by the object (and not its prototype). `Object.entries()` would be a better fit here, but it's poorly supported in old browsers.

If someone else has the problem and you don't merge this proposition, you can tell them that...
```
import Vuex from 'vuex';
import * as actions from './actions';

const store = new Vuex.Store({
  // ...
  actions: makeCancellable({
      ...actions
  })
});
```
...will also fix the problem.